### PR TITLE
메인 화면에 통계 정보를 추가했습니다.

### DIFF
--- a/src/components/total-stats/TotalStats.tsx
+++ b/src/components/total-stats/TotalStats.tsx
@@ -1,0 +1,26 @@
+import useCountUp from 'hooks/useCountUp';
+import React from 'react';
+
+interface TotalStatsProp {
+  gardenCount: number;
+  plantCount: number;
+}
+
+const TotalStats: React.FC<TotalStatsProp> = ({ gardenCount, plantCount }) => {
+  const gardenCounting = useCountUp(gardenCount);
+  const plantCounting = useCountUp(plantCount);
+
+  return (
+    <div>
+      <p>
+        현재 <span className='text-btnColor-200'>{gardenCounting}</span>개의 텃밭에
+      </p>
+      <p>
+        <span className='text-btnColor-200'>&emsp;&nbsp;&nbsp;&nbsp;&nbsp;{plantCounting}</span>
+        개의 씨앗이 심어졌어요!
+      </p>
+    </div>
+  );
+};
+
+export default TotalStats;

--- a/src/components/total-stats/index.ts
+++ b/src/components/total-stats/index.ts
@@ -1,0 +1,3 @@
+import TotalStats from './TotalStats';
+
+export default TotalStats;

--- a/src/hooks/useCountUp.ts
+++ b/src/hooks/useCountUp.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+export default function useCountUp(end: number) {
+  const [count, setCount] = useState(0);
+
+  let currentCount = end;
+
+  useEffect(() => {
+    const counter = setInterval(() => {
+      setCount(Math.ceil(end - currentCount));
+
+      if (currentCount < 1) {
+        clearInterval(counter);
+      }
+
+      const jump = currentCount / 10;
+
+      currentCount -= jump;
+    }, 50);
+  }, [end, currentCount]);
+
+  return count;
+}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,4 +1,5 @@
 import { main_image } from 'assets/image';
+import TotalStats from 'components/total-stats';
 import { useAppDispatch } from 'hooks';
 import React, { useEffect } from 'react';
 import { clearBase } from 'store/modules/base';
@@ -18,7 +19,7 @@ const Home: React.FC = () => {
         <h1 className='pt-7 text-3xl font-extrabold mb-7'>🌱 마음을 전하는 텃밭 🌱</h1>
         <p className='w-11/12 m-auto text-lg'>
           전하고 싶었던 말을 <br /> 시간이 지나면 잊을 때가 있지 않나요? <br /> <br />
-          전하고 싶지만 <br /> 나중에 확인해줬으면 하는 말들이 있어요.. <br /> <br />
+          {/* 전하고 싶지만 <br /> 나중에 확인해줬으면 하는 말들이 있어요.. <br /> <br /> */}
           씨앗에 글을 담아 텃밭에 심어주세요. <br /> 받은 사람이 가꾸고 확인해볼 거예요.
         </p>
 
@@ -37,6 +38,17 @@ const Home: React.FC = () => {
           <img className='w-auto h-full m-auto' src={main_image} alt='' />
         </div>
         <CreateOwnerBox />
+        <div
+          style={{
+            position: 'absolute',
+            bottom: '10%',
+            marginTop: '1.25rem',
+            fontSize: '1.6rem',
+            textAlign: 'left',
+          }}
+        >
+          <TotalStats gardenCount={128} plantCount={512} />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -19,7 +19,6 @@ const Home: React.FC = () => {
         <h1 className='pt-7 text-3xl font-extrabold mb-7'>🌱 마음을 전하는 텃밭 🌱</h1>
         <p className='w-11/12 m-auto text-lg'>
           전하고 싶었던 말을 <br /> 시간이 지나면 잊을 때가 있지 않나요? <br /> <br />
-          {/* 전하고 싶지만 <br /> 나중에 확인해줬으면 하는 말들이 있어요.. <br /> <br /> */}
           씨앗에 글을 담아 텃밭에 심어주세요. <br /> 받은 사람이 가꾸고 확인해볼 거예요.
         </p>
 
@@ -40,8 +39,6 @@ const Home: React.FC = () => {
         <CreateOwnerBox />
         <div
           style={{
-            position: 'absolute',
-            bottom: '10%',
             marginTop: '1.25rem',
             fontSize: '1.6rem',
             textAlign: 'left',


### PR DESCRIPTION
## 📄 구현 내용 설명
아래 사진과 같이 메인 화면에 보일 통계 정보를 추가했습니다.

![stat-counting](https://user-images.githubusercontent.com/59170680/211036540-0298db82-ed7b-4960-8f78-b33e7fe27c1a.gif)

그냥 통계 정보만 보여주면 심심할 것 같아서 천천히 숫자가 카운트 업 되는 효과를 적용했습니다!

**구현 과정**
1. useCountUp 훅을 만들어 로직을 해당 부분에 구현했습니다. 훅을 사용하는 방법은 `개수`를 파라미터로 넣어주면, `카운팅 업 되는 숫자`를 리턴해줍니다.
2. 통계를 보여주는 부분은 components/total-stats 폴더에 컴포넌트로 구현해 놓았습니다.
3. `Home.tsx` 파일에, 2번에서 만든 컴포넌트를 아래와 같이 사용하였습니다.
```
<div
  style={{
    position: 'absolute',
    bottom: '10%',
    marginTop: '1.25rem',
    fontSize: '1.6rem',
    textAlign: 'left',
  }}
>
  <TotalStats gardenCount={128} plantCount={512} />
</div>
```


### ⛱️ 주요 변경 사항
- useCountUp hook 제작
- TotalStats 컴포넌트 제작
- Home.tsx 화면에 통계 정보 노출

### 🙋 이 부분을 리뷰해주세요
- 커스텀 훅을 처음 만들어 봐서, 이렇게 만드는게 맞는지 잘 모르겠어요..!
- TotalStats 컴포넌트를 만들지 않고 그냥 메인화면에 바로 노출시키는게 나은지, 제 방식처럼 컴포넌트로 빼서 만드는게 좋은지는 조언 주시면 좋을 것 같습니다!
- 일단 `home` 페이지에는 인라인으로, `totalStats` 컴포넌트에는 기존에 정해놓은 컬러를 사용하기 위해 tailwind로 스타일링을 해놨습니다. 추후에 emotion으로 변경할게요!

### 🤔 이런 부분에서 에러가 날 수도 있어요
- 
-
