### PR TITLE
style: add wrapping style on keyword

### DIFF
--- a/src/pages/message-form/components/KeywordForm.tsx
+++ b/src/pages/message-form/components/KeywordForm.tsx
@@ -32,7 +32,7 @@ const KeywordForm: React.FC<KeywordFormProps> = ({ growingPeriod, isMaxKeywords,
     const enteredKeyword = keywordInput.current?.value;
 
     if (!enteredKeyword) {
-      handleError('* 입새를 입력해주세요');
+      handleError('* 잎새를 입력해주세요');
       return;
     }
     if (enteredKeyword.length > 10) {

--- a/src/pages/message-form/components/KeywordList.tsx
+++ b/src/pages/message-form/components/KeywordList.tsx
@@ -1,6 +1,5 @@
 import type { MouseEventHandler } from 'react';
 import React from 'react';
-
 interface KeywordListProps {
   keyWords: string[];
   deleteKeyword: (targetIndex: number) => void;
@@ -16,11 +15,11 @@ const KeywordList: React.FC<KeywordListProps> = ({ keyWords, deleteKeyword }) =>
   };
 
   return (
-    <ul className='flex flex-row h-9 [&>li+li]:ml-3'>
+    <ul id='keyword-list' className='flex flex-wrap'>
       {keyWords?.map((keyword, index) => (
         <li
           key={`${keyword}-${index}`}
-          className='rounded-lg border-2 bg-btnColor-200 text-textColor-200'
+          className='flex flex-wrap border-2 rounded-lg bg-btnColor-200 text-textColor-200 '
         >
           <button
             type='button'


### PR DESCRIPTION
📄 구현 내용 설명
![chrome-capture-2023-0-28](https://user-images.githubusercontent.com/57996351/215147097-e5a1c98a-6147-432b-acf7-914531255f6f.gif)
잎새 키워드가 overflow 되면 하단으로 쌓이게 스타일주었습니다.

⛱️ 주요 변경 사항
기존 스타일
![화면 캡처 2023-01-27 234340](https://user-images.githubusercontent.com/57996351/215147154-f3a5791a-a7d5-44b5-8e13-3cd720e09eb8.png)
파일 3개를 계속 건들여보면서 scroll 옵션도 주고 해봤는데요 이게 제일 깔끔한 것 같아서 이렇게 해두었습니다.