### PR TITLE
Title(header)을 통해 네비게이션이 가능하도록 기능을 추가하였습니다

### DIFF
--- a/src/pages/garden/Garden.tsx
+++ b/src/pages/garden/Garden.tsx
@@ -15,7 +15,7 @@ const Garden: React.FC<GardenProps> = (props) => {
   return (
     <div className='relative flex items-center justify-center w-full h-full'>
       <div className='relative py-[100px] z-20'>
-        <Title />
+        <Title isHost={props.isHost} />
         <Ground {...props} />
         <div className='absolute bottom-0 right-0'>
           <UrlShareButton />

--- a/src/pages/garden/components/Title.tsx
+++ b/src/pages/garden/components/Title.tsx
@@ -19,33 +19,35 @@ const Title: React.FC<TitleProps> = ({ isHost }) => {
   };
 
   return (
-    <h1 className='absolute top-0 left-0 z-10 w-full h-8 px-8 overflow-hidden rounded'>
-      <div className='absolute top-0 left-0 z-10 w-full h-8 px-4 bg-white opacity-60 blur-md'>
-        <div className='w-full'></div>
-      </div>
-      <div className='relative z-30 block text-3xl leading-8 text-center'>
-        <button onClick={clickGoBackButton} className=' absolute left-1' title='뒤로가기'>
-          {'<'}
-        </button>
-        <button onClick={clickGoGardenButton} title={`${name ?? ''}의 텃밭으로 가기`}>
-          {name ?? ''}의 텃밭
-        </button>
-      </div>
-      <div
-        style={{
-          marginTop: '1.25rem',
-          fontSize: '1.6rem',
-          textAlign: 'left',
-        }}
-      >
-        <p>
-          <span className='text-btnColor-200'>{name ?? '마음이의주말농장'}</span>&nbsp;텃밭에
-          <br />
-          <span className='inline-block w-16 text-right text-btnColor-200'>{8}&nbsp;</span>
-          개의 씨앗이 심어졌어요!
-        </p>
-      </div>
-    </h1>
+    <header className='absolute top-0 left-0 z-10 w-full h-8 px-8 overflow-hidden rounded'>
+      <h1>
+        <div className='absolute top-0 left-0 z-10 w-full h-8 px-4 bg-white opacity-60 blur-md'>
+          <div className='w-full'></div>
+        </div>
+        <div className='relative z-30 block text-3xl leading-8 text-center'>
+          <button onClick={clickGoBackButton} className=' absolute left-1' title='뒤로가기'>
+            {'<'}
+          </button>
+          <button onClick={clickGoGardenButton} title={`${name ?? ''}의 텃밭으로 가기`}>
+            {name ?? ''}의 텃밭
+          </button>
+        </div>
+        <div
+          style={{
+            marginTop: '1.25rem',
+            fontSize: '1.6rem',
+            textAlign: 'left',
+          }}
+        >
+          <p>
+            <span className='text-btnColor-200'>{name ?? '마음이의주말농장'}</span>&nbsp;텃밭에
+            <br />
+            <span className='inline-block w-16 text-right text-btnColor-200'>{8}&nbsp;</span>
+            개의 씨앗이 심어졌어요!
+          </p>
+        </div>
+      </h1>
+    </header>
   );
 };
 

--- a/src/pages/garden/components/Title.tsx
+++ b/src/pages/garden/components/Title.tsx
@@ -1,17 +1,36 @@
 import { useAppSelector } from 'hooks';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
-const Title: React.FC = () => {
-  const { name } = useAppSelector((state) => state.base);
+interface TitleProps {
+  isHost: boolean;
+}
+
+const Title: React.FC<TitleProps> = ({ isHost }) => {
+  const { name, uuid } = useAppSelector((state) => state.base);
+  const navigate = useNavigate();
+
+  const clickGoBackButton = () => {
+    navigate(-1);
+  };
+
+  const clickGoGardenButton = () => {
+    navigate(`/${isHost ? 'host' : 'guest'}/garden/${uuid}`);
+  };
 
   return (
     <h1 className='absolute top-0 left-0 z-10 w-full h-8 px-8 overflow-hidden rounded'>
       <div className='absolute top-0 left-0 z-10 w-full h-8 px-4 bg-white opacity-60 blur-md'>
         <div className='w-full'></div>
       </div>
-      <span className='relative z-30 block text-3xl leading-8 text-center'>
-        {name ?? ''}의 텃밭
-      </span>
+      <div className='relative z-30 block text-3xl leading-8 text-center'>
+        <button onClick={clickGoBackButton} className=' absolute left-1' title='뒤로가기'>
+          {'<'}
+        </button>
+        <button onClick={clickGoGardenButton} title={`${name ?? ''}의 텃밭으로 가기`}>
+          {name ?? ''}의 텃밭
+        </button>
+      </div>
       <div
         style={{
           marginTop: '1.25rem',

--- a/src/router/componenets/GuestDefaultTemplate.tsx
+++ b/src/router/componenets/GuestDefaultTemplate.tsx
@@ -1,3 +1,4 @@
+import Title from 'pages/garden/components/Title';
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 
@@ -6,7 +7,12 @@ import GuestWrapper from './GuestWrapper';
 const GuestDefaultTemplate: React.FC = () => {
   return (
     <GuestWrapper>
-      <Outlet />
+      <>
+        <Title isHost={false} />
+        <div className='pt-8'>
+          <Outlet />
+        </div>
+      </>
     </GuestWrapper>
   );
 };

--- a/src/router/componenets/HostDefaultTemplate.tsx
+++ b/src/router/componenets/HostDefaultTemplate.tsx
@@ -1,3 +1,4 @@
+import Title from 'pages/garden/components/Title';
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 
@@ -6,7 +7,12 @@ import HostWrapper from './HostWrapper';
 const HostDefaultTemplate: React.FC = () => {
   return (
     <HostWrapper>
-      <Outlet />
+      <>
+        <Title isHost />
+        <div className='pt-8'>
+          <Outlet />
+        </div>
+      </>
     </HostWrapper>
   );
 };


### PR DESCRIPTION
## 📄 구현 내용 설명
Title(header)을 통해 네비게이션이 가능하도록 기능을 추가하였습니다.
- 뒤로가기 버튼 클릭 시 전 화면으로 이동합니다
- ㅇㅇ의 텃밭 버튼 클릭 시 ㅇㅇ의 텃밭 화면으로 이동합니다.
    - 텃밭 주인인지(host) 아닌지(guest) 여부에 따라 각각 host/텃밭 guest/텃밭 페이지로 이동합니다.


### ⛱️ 주요 변경 사항
- 'ㅇㅇ의 텃밭' 타이틀이 텃밭 화면 내부에서만 나오는 것이 아니라 씨앗 페이지, 편지 읽기 페이지 등에서도 노출됩니다.

### 🙋 이 부분을 리뷰해주세요


### 🤔 이런 부분에서 에러가 날 수도 있어요

